### PR TITLE
test: added test for modal

### DIFF
--- a/src/components/shared/modal/modal.test.tsx
+++ b/src/components/shared/modal/modal.test.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import Modal from "./Modal";
+import { useState } from "react";
+
+type CustomModalWrapperProps = {
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+const CustomModalWrapper = ({ onOpen, onClose }: CustomModalWrapperProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="open-modal-btn"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        Open modal
+      </button>
+      <Modal open={isOpen} onOpen={onOpen} onClose={onClose}>
+        <div>modal content</div>
+      </Modal>
+    </>
+  );
+};
+
+test("should be able to toggle modal", () => {
+  const onOpen = jest.fn();
+  const onClose = jest.fn();
+
+  render(<CustomModalWrapper onOpen={onOpen} onClose={onClose} />);
+
+  expect(screen.queryByText(/modal-content/i)).toBeNull();
+
+  fireEvent.click(screen.getByTestId("open-modal-btn"));
+
+  expect(screen.queryByText(/modal-content/i)).toBeDefined();
+  // This doesn't get fired, ever (as it's not used in the component)
+  // expect(onOpen).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(screen.getByTestId("open-modal-btn"));
+
+  expect(screen.queryByText(/modal-content/i)).toBeNull();
+  // This doesn't get fired in this specific case, it's only use if we use the internal close button
+  // expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("should close after clicking the close button", () => {
+  const onClose = jest.fn();
+  render(
+    <Modal open closeButton onClose={onClose}>
+      <div>modal content</div>
+    </Modal>
+  );
+
+  expect(screen.queryByText(/modal-content/i)).toBeDefined();
+
+  fireEvent.click(screen.getByRole("button"));
+
+  expect(screen.queryByText(/modal-content/i)).toBeNull();
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("should render the modal with a title", () => {
+  render(
+    <Modal open title="modal title">
+      <div>modal content</div>
+    </Modal>
+  );
+
+  expect(screen.queryByText(/modal title/i)).toBeDefined();
+});


### PR DESCRIPTION
Fixes #21 

Getting my feet wet with some modal testing :) 

Let me know what we want to do about the following;
![Code-srccomponentssharedmodalmodal test tsx — atom-pwa_2021-02-26](https://user-images.githubusercontent.com/10127707/109333525-d8d50f00-785f-11eb-9bd2-18b80758d471.png)

**_Lines 88-91_** are uncovered because they never get called. _**Line 99**_ is covered in one test but could be removed there if it worked in the toggle test.
 
The gist is this: you can pass two functions `onClose` and `onOpen`. The `onOpen` handler doesn't ever get called, as the **_lines 88-91_** are never used in the modal component. The `onClose` only gets called if you close the modal with the button inside the component (not if you toggle the open state from the parent).

The unused lines;
![Code-srccomponentssharedmodalModal tsx — atom-pwa_2021-02-26](https://user-images.githubusercontent.com/10127707/109334242-c4454680-7860-11eb-8135-d63661aa31a3.png)
