### PR TITLE
chore: update coverage reporter action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,6 @@ jobs:
         run: yarn coverage:ci
 
       - name: Report coverage
-        uses: romeovs/lcov-reporter-action@v0.2.16
+        uses: romeovs/lcov-reporter-action@v0.2.21
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Turns out the failing report on the the `next` branch action might have been an issue in the version we are using and fixed in new versions. I raised [this issue](https://github.com/romeovs/lcov-reporter-action/issues/19), then found [this issue](https://github.com/romeovs/lcov-reporter-action/issues/16).

If this PR goes green, I'll just merge it so I can see what it does on `next`.