### PR TITLE
refactor(MassCalculator): add I as prefix for interfaces

### DIFF
--- a/src/components/mass-calculator/AddElementModal.tsx
+++ b/src/components/mass-calculator/AddElementModal.tsx
@@ -2,13 +2,13 @@ import * as React from "react";
 import Modal from "../shared/modal/Modal";
 import ElementPicker from "../element-picker/ElementPicker";
 
-interface AddElementModalProps {
+interface IAddElementModalProps {
   isOpen: boolean;
   onClose: () => void;
   onAdd: (atomic: number) => void;
 }
 
-function AddElementModal({ isOpen, onClose, onAdd }: AddElementModalProps) {
+function AddElementModal({ isOpen, onClose, onAdd }: IAddElementModalProps) {
   return (
     <Modal
       className="mass-calculator__add-element-modal"

--- a/src/components/mass-calculator/CalculatorElement.tsx
+++ b/src/components/mass-calculator/CalculatorElement.tsx
@@ -4,7 +4,7 @@ import Button from "../shared/button/Button";
 import { i18n } from "../../Locale";
 import ElementManager, { getElementLocales } from "../../ElementManager";
 
-interface CalculatorElementProps {
+interface ICalculatorElementProps {
   atomic: number;
   quantity: number;
   selectElement: (atomic: number) => void;
@@ -14,7 +14,7 @@ function CalculatorElement({
   atomic,
   quantity,
   selectElement,
-}: CalculatorElementProps) {
+}: ICalculatorElementProps) {
   const element = ElementManager.getElement(atomic);
 
   if (!element) {

--- a/src/components/mass-calculator/EditElementModal.tsx
+++ b/src/components/mass-calculator/EditElementModal.tsx
@@ -5,7 +5,7 @@ import { i18n } from "../../Locale";
 import ElementManager, { getElementLocales } from "../../ElementManager";
 import { IMassCalculatorElement } from "./hooks/useMassCalculator";
 
-interface EditElementModalProps {
+interface IEditElementModalProps {
   isOpen: boolean;
   onClose: () => void;
   increaseQuantity: () => void;
@@ -21,7 +21,7 @@ function EditElementModal({
   decreaseQuantity,
   changeQuantity,
   onClose,
-}: EditElementModalProps) {
+}: IEditElementModalProps) {
   if (!selectedElement) return null;
 
   const element = ElementManager.getElement(selectedElement.atomic);


### PR DESCRIPTION
I see that using I as prefix of interfaces is a naming convention so I have added to interfaces that I have created previously.