### PR TITLE
fix(IconButton): omit children prop from IconButtonProps

### DIFF
--- a/src/components/shared/icon-button/IconButton.tsx
+++ b/src/components/shared/icon-button/IconButton.tsx
@@ -4,7 +4,7 @@ import Button, { ButtonProps } from "../button/Button";
 import Icon from "../icon/Icon";
 import "./IconButton.scss";
 
-interface IconButtonProps extends ButtonProps {
+interface IconButtonProps extends Omit<ButtonProps, "children"> {
   iconName: string;
   text?: string;
   id?: string;


### PR DESCRIPTION
I forgot to omit the children prop in the IconButtonProps interface, and that's causing type checking issues.

This PR fixes that (it's also included in #132)