### PR TITLE
fix: fixes periodic table test retake

### DIFF
--- a/src/components/periodic-table-test/PeriodicTableTest.tsx
+++ b/src/components/periodic-table-test/PeriodicTableTest.tsx
@@ -176,7 +176,7 @@ function PeriodicTableTest() {
 
   function repeatTest() {
     clearResults();
-    createTestQuestions(settings);
+    setQuestions(createTestQuestions(settings));
   }
 
   function repeatWrongAnswers() {


### PR DESCRIPTION
Periodic Table Test retake functionality was broken because the test questions weren't set after clicking the button.